### PR TITLE
Add TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,18 @@
   "homepage": "https://microlink.io/user-agents",
   "version": "2.1.13",
   "exports": {
-    ".": "./src/index.js",
-    "./desktop": "./src/desktop.js",
-    "./mobile": "./src/mobile.js"
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./desktop":  {
+      "types": "./src/index.d.ts",
+      "default": "./src/desktop.js"
+    },
+    "./mobile":  {
+      "types": "./src/index.d.ts",
+      "default": "./src/mobile.js"
+    }
   },
   "author": {
     "email": "hello@microlink.io",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,2 @@
+declare const topUserAgents: string[];
+export = topUserAgents;


### PR DESCRIPTION
Hi @Kikobeats 👋  hope you're well

Quick PR to add TypeScript type declarations, to avoid the following issue in TypeScript code:

```
Could not find a declaration file for module 'top-user-agents'. '/Users/k/p/courses/node_modules/top-user-agents/src/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/top-user-agents` if it exists or add a new declaration (.d.ts) file containing `declare module 'top-user-agents';
```

![Screenshot 2024-03-10 at 11 54 18](https://github.com/microlinkhq/top-user-agents/assets/1935696/b52c1bca-f717-4a6a-ba05-0c66f82f6594)

This uses the `export =` syntax because the `src/index.js` file is a CommonJS file.