### PR TITLE
Add `types` for non `module: node` projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A list of most common User Agent.",
   "homepage": "https://microlink.io/user-agents",
   "version": "2.1.22",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": {
       "types": "./src/index.d.ts",


### PR DESCRIPTION
I am using `top-user-agents` inside an old project where neither `module: node` nor `module: nodenext` could be used. The PR adds `types` to `package.json` to support typescript legacy module resolution.