### PR TITLE
fix: exclude Shields.io

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -18,6 +18,7 @@ const EXCLUSIONS = [
   'dart/',
   'networkingextension',
   'retweet',
+  'shields.io',
   'supabaseedgeruntime/'
 ]
 

--- a/src/desktop.json
+++ b/src/desktop.json
@@ -48,7 +48,6 @@
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0",
-  "Shields.io/4604d4e",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.5938.132 Safari/537.36",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",

--- a/src/index.json
+++ b/src/index.json
@@ -65,7 +65,6 @@
   "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/425.6.927981711 Mobile/15E148 Safari/604.1",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0",
-  "Shields.io/4604d4e",
   "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/149.0.7827.137 Mobile/15E148 Safari/604.1",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.5938.132 Safari/537.36",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",


### PR DESCRIPTION
Same as #41/#42 (Cloudinary). `Shields.io/4604d4e` is a badge fetcher, not real browser traffic, so it should be filtered out.

- Add `shields.io` to the `EXCLUSIONS` list in `bin/util.js` so it never reappears on update.
- Remove the existing `Shields.io/4604d4e` entry from `src/index.json` and `src/desktop.json`.

closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)